### PR TITLE
Adds support for ImportError suggestions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,21 @@
-# didyoumean - "Did You Mean?" Functionality on AttributeError 
+# didyoumean - "Did You Mean?" Functionality on AttributeError or ImportError
 
 from setuptools import setup, find_packages, Extension
 from os.path import join, dirname
 
-didyoumean = Extension('didyoumean', 
-                       sources=['src/didyoumean.c', 
+didyoumean = Extension('didyoumean',
+                       sources=['src/didyoumean.c',
                                 'src/hook.c',
                                 'src/levenshtein.c',
                                 'src/safe_PyObject_Dir.c'],
-                       include_dirs=['src'], 
+                       include_dirs=['src'],
                        depends=['src/safe_PyObject_Dir.h'])
 
 setup(
     name='dutc-didyoumean',
     version='0.1.6',
-    description='"Did You Mean?" on AttributeError',
-    long_description=''.join(open(join(dirname(__file__),'README.md'))),
+    description='"Did You Mean?" on AttributeError or ImportError',
+    long_description=''.join(open(join(dirname(__file__), 'README.md'))),
     author='James Powell',
     author_email='james@dontusethiscode.com',
     url='https://github.com/dutc/didyoumean',


### PR DESCRIPTION
Not the prettiest code, sorry ;_;

Works by patching the internal c function on `__builtins__.__import__` in the same way that `getattr` does.

example:

```
In [1]: import didyoumean

In [2]: import tast
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-2-12cca5f88144> in <module>()
----> 1 import tast

ImportError: No module named tast

Maybe you meant: ast
```
